### PR TITLE
Fix bug.

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -13,7 +13,7 @@ class BooksController < ApplicationController
   end
 
   def show
-    @book = Book.find_by(params[:id])
+    @book = Book.find_by(id: params[:id])
     @comments = @book.comments
     @comment = Comment.new
   end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -12,7 +12,7 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+# port        ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
@@ -38,3 +38,5 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+bind "unix://#{Rails.root}/tmp/sockets/puma.sock"


### PR DESCRIPTION
There is bug that book detail page links only to specific pages.
The cause is that because no arguments were passed to `find_by` method, nil was returned.